### PR TITLE
Added 'F' case in GetGPA method of the BaseGradeBook class

### DIFF
--- a/GradeBook/GradeBooks/BaseGradeBook.cs
+++ b/GradeBook/GradeBooks/BaseGradeBook.cs
@@ -116,6 +116,8 @@ namespace GradeBook.GradeBooks
                     return 2;
                 case 'D':
                     return 1;
+                case 'F':
+                    return 0;
             }
             return 0;
         }


### PR DESCRIPTION
**Added 'F' case** in GetGPA method of the BaseGradeBook class to sync up with what is shown in the PluralSight Project: _Add Features to Grade Book Application Using C#_. The difference between the video and the source code is shown in the _Add Support for Weighted Grading_ section at ~3:25