### PR TITLE
Updated tests to work properly with test runner updates made in 2019

### DIFF
--- a/GradeBookTests/AddMultipleGradeBookTypeSupportToStartingUserInterfaceTests.cs
+++ b/GradeBookTests/AddMultipleGradeBookTypeSupportToStartingUserInterfaceTests.cs
@@ -15,10 +15,8 @@ namespace GradeBookTests
         public void IncreasePartsCheckToThreeTest()
         {
             //Bypass Test if Create Command for Weighted GPA has been started
-            var rankedGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                   from type in assembly.GetTypes()
-                                   where type.FullName == "GradeBook.GradeBooks.RankedGradeBook"
-                                   select type).FirstOrDefault();
+            var rankedGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
+            Assert.True(rankedGradeBook != null, "`RankedGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             var ctor = rankedGradeBook.GetConstructors().FirstOrDefault();
 
@@ -61,10 +59,8 @@ namespace GradeBookTests
         public void UpdateValidationMessageTest()
         {
             //Bypass Test if Create Command for Weighted GPA has been started
-            var rankedGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                   from type in assembly.GetTypes()
-                                   where type.FullName == "GradeBook.GradeBooks.RankedGradeBook"
-                                   select type).FirstOrDefault();
+            var rankedGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
+            Assert.True(rankedGradeBook != null, "`RankedGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             var ctor = rankedGradeBook.GetConstructors().FirstOrDefault();
 
@@ -107,10 +103,8 @@ namespace GradeBookTests
         public void InstantiateGradeBookTest()
         {
             //Bypass Test if Create Command for Weighted GPA has been started
-            var rankedGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                   from type in assembly.GetTypes()
-                                   where type.FullName == "GradeBook.GradeBooks.RankedGradeBook"
-                                   select type).FirstOrDefault();
+            var rankedGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
+            Assert.True(rankedGradeBook != null, "`RankedGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             var ctor = rankedGradeBook.GetConstructors().FirstOrDefault();
 
@@ -205,12 +199,13 @@ namespace GradeBookTests
         {
             //Setup Test
             var output = string.Empty;
-            Console.Clear();
+
             try
             {
                 using (var consoleInputStream = new StringReader("close"))
                 {
                     Console.SetIn(consoleInputStream);
+
                     using (var consolestream = new StringWriter())
                     {
                         Console.SetOut(consolestream);

--- a/GradeBookTests/AddNewGradeBookTypeEnumToBaseGradeBookTests.cs
+++ b/GradeBookTests/AddNewGradeBookTypeEnumToBaseGradeBookTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using GradeBook.GradeBooks;
 using Xunit;
 
@@ -27,10 +26,7 @@ namespace GradeBookTests
             Assert.True(File.Exists(filePath), "`GradeBookType.cs` was not found in the `Enums` directory.");
 
             // Get GradeBookType from the GradeBook.Enums namespace
-            var gradebookEnum = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                 from type in assembly.GetTypes()
-                                 where type.FullName == "GradeBook.Enums.GradeBookType"
-                                 select type).FirstOrDefault();
+            var gradebookEnum = TestHelpers.GetUserType("GradeBook.Enums.GradeBookType");
 
             // Assert GradeBookType was found in the GradeBook.Enums namespace
             Assert.True(gradebookEnum != null, "`GradeBookType` wasn't found in the `GradeBooks.Enums` namespace.");
@@ -70,10 +66,7 @@ namespace GradeBookTests
             Assert.True(typeProperty != null, "`GradeBook.GradeBooks.BaseGradeBook` doesn't contain a property `Type` or `Type` is not `public`.");
 
             // Get GradeBookType Enum from GradeBook.Enums namespace
-            var gradebookEnum = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                 from type in assembly.GetTypes()
-                                 where type.FullName == "GradeBook.Enums.GradeBookType"
-                                 select type).FirstOrDefault();
+            var gradebookEnum = TestHelpers.GetUserType("GradeBook.Enums.GradeBookType");
 
             // Test that the property Type is of type GradeBookType
             Assert.True(typeProperty.PropertyType == gradebookEnum, "`GradeBook.GradeBooks.BaseGradeBook` contains a property `Type` but it is not of type `GradeBookType`.");

--- a/GradeBookTests/AddWeightedSupportToBaseGradeBook.cs
+++ b/GradeBookTests/AddWeightedSupportToBaseGradeBook.cs
@@ -26,10 +26,8 @@ namespace GradeBookTests
         public void RefactorGradeBooksAndStartingUserInterface()
         {
             // Get the StandardGradeBook type
-            var standardGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                     from type in assembly.GetTypes()
-                                     where type.Name == "StandardGradeBook"
-                                     select type).FirstOrDefault();
+            var standardGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.StandardGradeBook");
+            Assert.True(standardGradeBook != null, "`StandardGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             // Get the StandardGradeBook's constructor
             var constructor = standardGradeBook.GetConstructors().FirstOrDefault();
@@ -51,10 +49,8 @@ namespace GradeBookTests
         public void SetIsWeightedInBaseGradeBookConstructorTest()
         {
             // get standardgradebook type
-            var standardGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                     from type in assembly.GetTypes()
-                                     where type.Name == "StandardGradeBook"
-                                     select type).FirstOrDefault();
+            var standardGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.StandardGradeBook");
+            Assert.True(standardGradeBook != null, "`StandardGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             // Instantiate StandardGradeBook with weighted grading
             object gradeBook = Activator.CreateInstance(standardGradeBook, "WeightedTest", true);
@@ -71,7 +67,6 @@ namespace GradeBookTests
         {
             //Setup Test
             var output = string.Empty;
-            Console.Clear();
 
             try
             {
@@ -104,7 +99,7 @@ namespace GradeBookTests
             }
 
             output = string.Empty;
-            Console.Clear();
+
             try
             {
                 using (var consoleInputStream = new StringReader("close"))

--- a/GradeBookTests/AddWeightedSupportToStartingUserInterfaceTests.cs
+++ b/GradeBookTests/AddWeightedSupportToStartingUserInterfaceTests.cs
@@ -15,7 +15,7 @@ namespace GradeBookTests
         {
             //Setup Test
             var output = string.Empty;
-            Console.Clear();
+
             try
             {
                 using (var consoleInputStream = new StringReader("close"))

--- a/GradeBookTests/CreateStandardGradeBookandRankedGradeBookClassesTests.cs
+++ b/GradeBookTests/CreateStandardGradeBookandRankedGradeBookClassesTests.cs
@@ -27,10 +27,7 @@ namespace GradeBookTests
             Assert.True(File.Exists(filePath), "`StandardGradeBook.cs` was not found in the `GradeBooks` folder.");
 
             // Get GradeBookType from the GradeBook.Enums namespace
-            var gradebook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                             from type in assembly.GetTypes()
-                             where type.FullName == "GradeBook.GradeBooks.StandardGradeBook"
-                             select type).FirstOrDefault();
+            var gradebook = TestHelpers.GetUserType("GradeBook.GradeBooks.StandardGradeBook");
 
             // Assert StandardGradeBook was found in the GradeBook.GradeBooks namespace
             Assert.True(gradebook != null, "`StandardGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
@@ -49,10 +46,8 @@ namespace GradeBookTests
         public void UpdateStandardGradeBookTypeTests()
         {
             // Get StandardGradeBook from the GradeBook.GradeBooks namespace
-            var gradebook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                             from type in assembly.GetTypes()
-                             where type.FullName == "GradeBook.GradeBooks.StandardGradeBook"
-                             select type).FirstOrDefault();
+            var gradebook = TestHelpers.GetUserType("GradeBook.GradeBooks.StandardGradeBook");
+            Assert.True(gradebook != null, "`StandardGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             // Get StandardGradeBook's first constructor (should be the only constructor)
             var constructor = gradebook.GetConstructors().FirstOrDefault();
@@ -61,10 +56,8 @@ namespace GradeBookTests
             Assert.True(constructor != null, "No constructor found for GradeBook.GradeBooks.StandardGradeBook.");
 
             // Get GradeBookType from the GradeBook.Enums namespace
-            var gradebookEnum = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                 from type in assembly.GetTypes()
-                                 where type.FullName == "GradeBook.Enums.GradeBookType"
-                                 select type).FirstOrDefault();
+            var gradebookEnum = TestHelpers.GetUserType("GradeBook.Enums.GradeBookType");
+            Assert.True(gradebookEnum != null, "`GradeBookType` wasn't found in the `GradeBook.Enums` namespace.");
 
             // Get constructor's parameters
             var parameters = constructor.GetParameters();
@@ -105,10 +98,7 @@ namespace GradeBookTests
             Assert.True(File.Exists(filePath), "`RankedGradeBook.cs` was not found in the `GradeBooks` folder.");
         
             // Get GradeBookType from the GradeBook.Enums namespace
-            var gradebook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                 from type in assembly.GetTypes()
-                                 where type.FullName == "GradeBook.GradeBooks.RankedGradeBook"
-                                 select type).FirstOrDefault();
+            var gradebook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
 
             // Assert RankedGradeBook was found in the GradeBook.GradeBooks namespace
             Assert.True(gradebook != null, "`RankedGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
@@ -127,10 +117,8 @@ namespace GradeBookTests
         public void UpdateRankedGradeBookTypeTest()
         {
             // Get RankedGradeBook from the GradeBook.GradeBooks namespace
-            var gradebook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                             from type in assembly.GetTypes()
-                             where type.FullName == "GradeBook.GradeBooks.RankedGradeBook"
-                             select type).FirstOrDefault();
+            var gradebook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
+            Assert.True(gradebook != null, "`RankedGradeBook` wasn't found in the `GradeBook.GradeBooks` namespace.");
 
             // Get RankedGradeBook's first constructor (should be the only constructor)
             var constructor = gradebook.GetConstructors().FirstOrDefault();
@@ -139,10 +127,8 @@ namespace GradeBookTests
             Assert.True(constructor != null, "No constructor found for GradeBook.GradeBooks.StardardGradeBook.");
 
             // Get GradeBookType from the GradeBook.Enums namespace
-            var gradebookEnum = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                 from type in assembly.GetTypes()
-                                 where type.FullName == "GradeBook.Enums.GradeBookType"
-                                 select type).FirstOrDefault();
+            var gradebookEnum = TestHelpers.GetUserType("GradeBook.Enums.GradeBookType");
+            Assert.True(gradebookEnum != null, "`GradeBookType` wasn't found in the `GradeBook.Enums` namespace.");
 
             // Get constructor's parameters
             var parameters = constructor.GetParameters();

--- a/GradeBookTests/CreateStatisticsOverridesTests.cs
+++ b/GradeBookTests/CreateStatisticsOverridesTests.cs
@@ -18,10 +18,8 @@ namespace GradeBookTests
         public void OverrideCalculateStatisticsTest()
         {
             //Setup Test
-            var rankedGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                   from type in assembly.GetTypes()
-                                   where type.FullName == "GradeBook.GradeBooks.RankedGradeBook"
-                                   select type).FirstOrDefault();
+            var rankedGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
+            Assert.True(rankedGradeBook != null, "`RankedGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             var ctor = rankedGradeBook.GetConstructors().FirstOrDefault();
 
@@ -34,7 +32,7 @@ namespace GradeBookTests
 
             MethodInfo method = rankedGradeBook.GetMethod("CalculateStatistics");
             var output = string.Empty;
-            Console.Clear();
+
             try
             {
                 //Test that message was written to console when there are less than 5 students.
@@ -84,7 +82,6 @@ namespace GradeBookTests
 
             //Test that the base calculate statistics did run when there were 5 or more students.
             output = string.Empty;
-            Console.Clear();
 
             try
             {
@@ -111,10 +108,7 @@ namespace GradeBookTests
         public void OverrideCalculateStudentStatisticsTest()
         {
             //Setup Test
-            var rankedGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                   from type in assembly.GetTypes()
-                                   where type.FullName == "GradeBook.GradeBooks.RankedGradeBook"
-                                   select type).FirstOrDefault();
+            var rankedGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
             Assert.True(rankedGradeBook != null, "GradeBook.GradeBooks.RankedGradeBook doesn't exist.");
 
             var ctor = rankedGradeBook.GetConstructors().FirstOrDefault();
@@ -141,7 +135,7 @@ namespace GradeBookTests
             gradeBook.GetType().GetProperty("Students").SetValue(gradeBook, students);
 
             var output = string.Empty;
-            Console.Clear();
+
             try
             {
                 //Test that message was written to console when there are less than 5 students.
@@ -191,7 +185,6 @@ namespace GradeBookTests
 
             //Test that the base calculate statistics did run when there were 5 or more students.
             output = string.Empty;
-            Console.Clear();
 
             try
             {

--- a/GradeBookTests/OverrideRankedGradeBooksGetLetterGradeTests.cs
+++ b/GradeBookTests/OverrideRankedGradeBooksGetLetterGradeTests.cs
@@ -19,10 +19,8 @@ namespace GradeBookTests
         public void CreateGetLetterGradeOverrideTests()
         {
             // Setup Test
-            var rankedGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                   from type in assembly.GetTypes()
-                                   where type.Name == "RankedGradeBook"
-                                   select type).FirstOrDefault();
+            var rankedGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
+            Assert.True(rankedGradeBook != null, "`RankedGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             var constructor = rankedGradeBook.GetConstructors().FirstOrDefault();
             var parameters = constructor.GetParameters();
@@ -97,10 +95,8 @@ namespace GradeBookTests
         public void TopTwentyPercentGetAnATests()
         {
             // Setup Test
-            var rankedGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                   from type in assembly.GetTypes()
-                                   where type.Name == "RankedGradeBook"
-                                   select type).FirstOrDefault();
+            var rankedGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
+            Assert.True(rankedGradeBook != null, "`RankedGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             var constructor = rankedGradeBook.GetConstructors().FirstOrDefault();
             var parameters = constructor.GetParameters();
@@ -171,10 +167,8 @@ namespace GradeBookTests
         public void SecondTwentyPercentGetABTests()
         {
             // Setup Test
-            var rankedGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                   from type in assembly.GetTypes()
-                                   where type.Name == "RankedGradeBook"
-                                   select type).FirstOrDefault();
+            var rankedGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
+            Assert.True(rankedGradeBook != null, "`RankedGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             var constructor = rankedGradeBook.GetConstructors().FirstOrDefault();
             var parameters = constructor.GetParameters();
@@ -224,10 +218,8 @@ namespace GradeBookTests
         public void ThirdTwentyPercentGetACTests()
         {
             // Setup Test
-            var rankedGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                   from type in assembly.GetTypes()
-                                   where type.Name == "RankedGradeBook"
-                                   select type).FirstOrDefault();
+            var rankedGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
+            Assert.True(rankedGradeBook != null, "`RankedGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             var constructor = rankedGradeBook.GetConstructors().FirstOrDefault();
             var parameters = constructor.GetParameters();
@@ -277,10 +269,8 @@ namespace GradeBookTests
         public void FourthTwentyPercentGetADTests()
         {
             // Setup Test
-            var rankedGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                   from type in assembly.GetTypes()
-                                   where type.Name == "RankedGradeBook"
-                                   select type).FirstOrDefault();
+            var rankedGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.RankedGradeBook");
+            Assert.True(rankedGradeBook != null, "`RankedGradeBook` wasn't found in the `GradeBooks.GradeBook` namespace.");
 
             var constructor = rankedGradeBook.GetConstructors().FirstOrDefault();
             var parameters = constructor.GetParameters();

--- a/GradeBookTests/TestHelpers.cs
+++ b/GradeBookTests/TestHelpers.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq;
+
+namespace GradeBookTests
+{
+    public static class TestHelpers
+    {
+        private static readonly string _projectName = "GradeBook";
+
+        public static Type GetUserType(string fullName)
+        {
+            return (from assembly in AppDomain.CurrentDomain.GetAssemblies()
+                    where assembly.FullName.StartsWith(_projectName)
+                    from type in assembly.GetTypes()
+                    where type.FullName == fullName
+                    select type).FirstOrDefault();
+        }
+    }
+}

--- a/GradeBookTests/UpdateGPACalculationsToSupportWeightedGPATests.cs
+++ b/GradeBookTests/UpdateGPACalculationsToSupportWeightedGPATests.cs
@@ -15,10 +15,7 @@ namespace GradeBookTests
         [Fact(DisplayName = "Update BaseGradeBooks GetGPA Method Test @update-basegradebook-s-getgpa-method")]
         public void GetWeightedGPATest()
         {
-            var standardGradeBook = (from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                                     from type in assembly.GetTypes()
-                                     where type.Name == "StandardGradeBook"
-                                     select type).FirstOrDefault();
+            var standardGradeBook = TestHelpers.GetUserType("GradeBook.GradeBooks.StandardGradeBook");
             Assert.True(standardGradeBook != null, "`GradeBook.GradeBooks.StandardGradeBook` doesn't exist.");
 
             // Test if `StandardGradeBook` is `public`.

--- a/GradeBookTests/xunit.runner.json
+++ b/GradeBookTests/xunit.runner.json
@@ -1,4 +1,5 @@
 {
+  "maxParallelThreads": 1,
   "parallelizeAssembly": false,
   "parallelizeTestCollections": false
 }


### PR DESCRIPTION
It appears there were undocumented changes to the .NET test runners (I'm still unable to verify exactly what changed)

As a results our use of reflection needed to be changed (it probably should have been changed regardless of this) to be a bit stricter on where it was looking.

In addition to this changes in the test runner also caused some issues with our tests interacting with the Console, specifically the use of Console.Clear is no longer safe from tests. (which was done strictly to prevent false positives. The good news is their changes reduced the risk of false positives to begin with so Console.Clear isn't entirely necessary. (there is some increased risk of false successes with our console tasks because of this, but I think it'll be pretty limited to the point I was unable to force a false success while intentionally creating conditions that should increase that risk)